### PR TITLE
fix right camera placement

### DIFF
--- a/reemc_description/urdf/sensors/prosilica_stereo_camera.gazebo.xacro
+++ b/reemc_description/urdf/sensors/prosilica_stereo_camera.gazebo.xacro
@@ -28,7 +28,7 @@
           </clip>
         </camera>
     <camera name="right">
-          <pose>0 0 ${-hack_baseline} 0 0 0</pose>  <!-- the pose is wrt to head_2_link because gazebo does not support "fixed" joints -->
+          <pose>0 -${hack_baseline} 0 0 0 0</pose>  <!-- the pose is wrt /stereo_link which is the parent of stereo_optical_frame -->
           <horizontal_fov>${ hfov }</horizontal_fov>
           <image>
             <width>${image_width} </width>


### PR DESCRIPTION
the right camera pose must be specified wrt /stereo_link and it was specified in /head_2_link. That caused the right camera be actually in front of the left camera rather than aside
