### PR TITLE
Switch Y_UP to Z_UP for all up_axis field of the meshes.

### DIFF
--- a/reemc_description/meshes/arm/arm_5.dae
+++ b/reemc_description/meshes/arm/arm_5.dae
@@ -5,7 +5,7 @@
             <author>VCGLab</author>
             <authoring_tool>VCGLib | MeshLab</authoring_tool>
         </contributor>
-        <up_axis>Y_UP</up_axis>
+        <up_axis>Z_UP</up_axis>
         <created>Fri Nov 1 10:20:23 2013</created>
         <modified>Fri Nov 1 10:20:23 2013</modified>
     </asset>

--- a/reemc_description/meshes/base/base.dae
+++ b/reemc_description/meshes/base/base.dae
@@ -5,7 +5,7 @@
             <author>VCGLab</author>
             <authoring_tool>VCGLib | MeshLab</authoring_tool>
         </contributor>
-        <up_axis>Y_UP</up_axis>
+        <up_axis>Z_UP</up_axis>
         <created>Thu Oct 31 08:53:01 2013</created>
         <modified>Thu Oct 31 08:53:01 2013</modified>
     </asset>

--- a/reemc_description/meshes/head/head_1.dae
+++ b/reemc_description/meshes/head/head_1.dae
@@ -5,7 +5,7 @@
             <author>VCGLab</author>
             <authoring_tool>VCGLib | MeshLab</authoring_tool>
         </contributor>
-        <up_axis>Y_UP</up_axis>
+        <up_axis>Z_UP</up_axis>
         <created>Fri Nov 1 13:02:23 2013</created>
         <modified>Fri Nov 1 13:02:23 2013</modified>
     </asset>

--- a/reemc_description/meshes/head/head_2.dae
+++ b/reemc_description/meshes/head/head_2.dae
@@ -5,7 +5,7 @@
             <author>VCGLab</author>
             <authoring_tool>VCGLib | MeshLab</authoring_tool>
         </contributor>
-        <up_axis>Y_UP</up_axis>
+        <up_axis>Z_UP</up_axis>
         <created>Fri Nov 1 13:04:04 2013</created>
         <modified>Fri Nov 1 13:04:04 2013</modified>
     </asset>

--- a/reemc_description/meshes/leg/leg_1.dae
+++ b/reemc_description/meshes/leg/leg_1.dae
@@ -5,7 +5,7 @@
             <author>VCGLab</author>
             <authoring_tool>VCGLib | MeshLab</authoring_tool>
         </contributor>
-        <up_axis>Y_UP</up_axis>
+        <up_axis>Z_UP</up_axis>
         <created>Wed Oct 30 10:45:00 2013</created>
         <modified>Wed Oct 30 10:45:00 2013</modified>
     </asset>

--- a/reemc_description/meshes/leg/leg_3.dae
+++ b/reemc_description/meshes/leg/leg_3.dae
@@ -5,7 +5,7 @@
             <author>VCGLab</author>
             <authoring_tool>VCGLib | MeshLab</authoring_tool>
         </contributor>
-        <up_axis>Y_UP</up_axis>
+        <up_axis>Z_UP</up_axis>
         <created>Wed Oct 30 10:36:07 2013</created>
         <modified>Wed Oct 30 10:36:07 2013</modified>
     </asset>

--- a/reemc_description/meshes/leg/leg_4.dae
+++ b/reemc_description/meshes/leg/leg_4.dae
@@ -5,7 +5,7 @@
             <author>VCGLab</author>
             <authoring_tool>VCGLib | MeshLab</authoring_tool>
         </contributor>
-        <up_axis>Y_UP</up_axis>
+        <up_axis>Z_UP</up_axis>
         <created>Wed Oct 30 10:55:01 2013</created>
         <modified>Wed Oct 30 10:55:01 2013</modified>
     </asset>

--- a/reemc_description/meshes/leg/leg_6.dae
+++ b/reemc_description/meshes/leg/leg_6.dae
@@ -5,7 +5,7 @@
             <author>VCGLab</author>
             <authoring_tool>VCGLib | MeshLab</authoring_tool>
         </contributor>
-        <up_axis>Y_UP</up_axis>
+        <up_axis>Z_UP</up_axis>
         <created>Wed Oct 30 11:50:32 2013</created>
         <modified>Wed Oct 30 11:50:32 2013</modified>
     </asset>

--- a/reemc_description/meshes/sensors/xtion_pro_live/xtion_pro_live.dae
+++ b/reemc_description/meshes/sensors/xtion_pro_live/xtion_pro_live.dae
@@ -5,7 +5,7 @@
             <author>VCGLab</author>
             <authoring_tool>VCGLib | MeshLab</authoring_tool>
         </contributor>
-        <up_axis>Y_UP</up_axis>
+        <up_axis>Z_UP</up_axis>
         <created>Wed Jan 16 14:35:13 2013</created>
         <modified>Wed Jan 16 14:35:13 2013</modified>
     </asset>

--- a/reemc_description/meshes/torso/torso_2.dae
+++ b/reemc_description/meshes/torso/torso_2.dae
@@ -5,7 +5,7 @@
             <author>VCGLab</author>
             <authoring_tool>VCGLib | MeshLab</authoring_tool>
         </contributor>
-        <up_axis>Y_UP</up_axis>
+        <up_axis>Z_UP</up_axis>
         <created>Fri Nov 1 11:28:39 2013</created>
         <modified>Fri Nov 1 11:28:39 2013</modified>
     </asset>


### PR DESCRIPTION
Y_UP introduces a transform between the original geometry of the body.
Rviz is explicitly removing this transform, see
https://github.com/ros-visualization/rviz/blob/8a010bbda36d425129dc06887eddcab032459319/src/rviz/mesh_loader.cpp#L233
This commit makes sure that this transform is coherent with the robot model.
